### PR TITLE
Adding secret to aws keys

### DIFF
--- a/lib/fluent/plugin/out_kinesis_firehose.rb
+++ b/lib/fluent/plugin/out_kinesis_firehose.rb
@@ -16,8 +16,8 @@ class Fluent::KinesisFirehoseOutput < Fluent::BufferedOutput
 
   config_param :profile,              :string, :default => nil
   config_param :credentials_path,     :string, :default => nil
-  config_param :aws_key_id,           :string, :default => nil
-  config_param :aws_sec_key,          :string, :default => nil
+  config_param :aws_key_id,           :string, :default => nil, :secret => true
+  config_param :aws_sec_key,          :string, :default => nil, :secret => true
   config_param :region,               :string, :default => nil
   config_param :endpoint,             :string, :default => nil
   config_param :http_proxy,           :string, :default => nil


### PR DESCRIPTION
This masks the keys when printing to logs. Currently without it prints the keys in plain text to log files under the `INFO` level.
