### PR TITLE
Add support for writing failed retried messages to local fallback file.

### DIFF
--- a/lib/fluent/plugin/out_kinesis_firehose.rb
+++ b/lib/fluent/plugin/out_kinesis_firehose.rb
@@ -25,6 +25,7 @@ class Fluent::KinesisFirehoseOutput < Fluent::BufferedOutput
   config_param :data_key,                  :string,  :default => nil
   config_param :append_new_line,           :bool,    :default => true
   config_param :retries_on_putrecordbatch, :integer, :default => 3
+  config_param :local_path_fallback,       :string,  :default => nil
 
   def initialize
     super
@@ -121,6 +122,12 @@ class Fluent::KinesisFirehoseOutput < Fluent::BufferedOutput
             record[:data]
           ]
         }
+
+        if not @local_path_fallback.nil?
+          File.open(@local_path_fallback, 'a') { |f|
+            failed_records.each { |record| f.write record[:data] }
+          }
+        end
       end
     end
   end

--- a/spec/out_kinesis_firehose_config_spec.rb
+++ b/spec/out_kinesis_firehose_config_spec.rb
@@ -27,6 +27,7 @@ describe 'Fluent::KinesisFirehoseOutput#configure' do
       expect(driver.instance.data_key).to be_nil
       expect(driver.instance.append_new_line).to be_truthy
       expect(driver.instance.retries_on_putrecordbatch).to eq 3
+      expect(driver.instance.local_path_fallback).to be_nil
     end
   end
 
@@ -45,6 +46,7 @@ describe 'Fluent::KinesisFirehoseOutput#configure' do
         data_key data
         append_new_line false
         retries_on_putrecordbatch 4
+        local_path_fallback /path/to/local/file
       EOS
     end
 
@@ -60,6 +62,7 @@ describe 'Fluent::KinesisFirehoseOutput#configure' do
       expect(driver.instance.data_key).to eq 'data'
       expect(driver.instance.append_new_line).to be_falsey
       expect(driver.instance.retries_on_putrecordbatch).to eq 4
+      expect(driver.instance.local_path_fallback).to eq '/path/to/local/file'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'fluent/test'
 require 'fluent/plugin/out_kinesis_firehose'
 require 'aws-sdk'
+require 'stringio'
 
 # Disable Test::Unit
 module Test::Unit::RunCount; def run(*); end; end


### PR DESCRIPTION
We are using this plugin, but have a need to ensure that we never lose events. I have added the ability to write events that fail to post to a local fallback file.

Thanks~
Adrian
